### PR TITLE
Add PostgreSQL database with automated backup services

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -21,6 +21,7 @@ env:
   S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
   S3_ACCESS_KEY_ID: ${{ vars.S3_ACCESS_KEY_ID }}
   S3_ENDPOINT: ${{ vars.S3_ENDPOINT }}
+  EMAIL: ${{ vars.EMAIL }}
 
 jobs:
   build-and-push:
@@ -45,6 +46,9 @@ jobs:
           - name: telegraf
             context: ./telegraf
             image: telegraf
+          - name: postgres-backup
+            context: ./postgres-backup
+            image: postgres-backup
     
     runs-on: ubuntu-latest
     permissions:
@@ -92,6 +96,7 @@ jobs:
             write_var S3_SECRET_ACCESS_KEY
             write_var S3_ACCESS_KEY_ID
             write_var S3_ENDPOINT
+            write_var EMAIL
 
       - name: Docker Stack Deploy
         uses: cssnr/stack-deploy-action@v1

--- a/caddy/CaddyFile
+++ b/caddy/CaddyFile
@@ -33,3 +33,7 @@ compass.nu31.space {
         reverse_proxy * infra_mongo-rs-viewer:8080
 }
 
+pgadmin.nu31.space {
+        reverse_proxy * infra_postgres-viewer:80
+}
+

--- a/docker-stack.local.yml
+++ b/docker-stack.local.yml
@@ -54,8 +54,41 @@ services:
       restart_policy:
         condition: on-failure
 
+  postgres:
+    image: postgres:17
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=${USERNAME}
+      - POSTGRES_PASSWORD=${PASSWORD}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - postgres-net
+    deploy:
+      restart_policy:
+        condition: on-failure
+
+  postgres-viewer:
+    image: dpage/pgadmin4:9
+    ports:
+      - "5050:80"
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=root@local.dev
+      - PGADMIN_DEFAULT_PASSWORD=${PASSWORD}
+    networks:
+      - postgres-net
+    deploy:
+      restart_policy:
+        condition: on-failure
+
 networks:
   mongo-rs-net:
+    driver: overlay
+    attachable: true
+    driver_opts:
+      encrypted: "true"
+  postgres-net:
     driver: overlay
     attachable: true
     driver_opts:
@@ -63,3 +96,4 @@ networks:
 
 volumes:
   mongodb-rs-1-data:
+  postgres-data:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -149,6 +149,115 @@ services:
       restart_policy:
         condition: none
 
+  postgres:
+    image: postgres:17
+    environment:
+      - POSTGRES_USER=${USERNAME}
+      - POSTGRES_PASSWORD=${PASSWORD}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - postgres-net
+    deploy:
+      restart_policy:
+        condition: on-failure
+
+  postgres-viewer:
+    image: dpage/pgadmin4:9
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=${EMAIL}
+      - PGADMIN_DEFAULT_PASSWORD=${PASSWORD}
+      - PGADMIN_CONFIG_SERVER_MODE=True
+    volumes:
+      - pgadmin-data:/var/lib/pgadmin
+    networks:
+      - postgres-net
+      - reverse-proxy
+    deploy:
+      restart_policy:
+        condition: on-failure
+
+  postgres-backup-hourly:
+    image: ghcr.io/${OWNER_NAME}/postgres-backup:${GIT_COMMIT_SHA}
+    command: ["/usr/local/bin/backup.sh"]
+    depends_on:
+      - cron
+      - postgres
+    environment:
+      - S3_ENDPOINT=${S3_ENDPOINT}
+      - PGHOST=postgres
+      - PGUSER=${USERNAME}
+      - PGPASSWORD=${PASSWORD}
+      - S3_BUCKET=${S3_BUCKET}
+      - S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
+      - S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}
+      - S3_FOLDER=postgres-hourly
+    networks:
+      - postgres-net
+    deploy:
+      mode: replicated
+      replicas: 0
+      labels:
+        - "swarm.cronjob.enable=true"
+        - "swarm.cronjob.schedule=10 * * * *"
+        - "swarm.cronjob.skip-running=true"
+      restart_policy:
+        condition: none
+
+  postgres-backup-daily:
+    image: ghcr.io/${OWNER_NAME}/postgres-backup:${GIT_COMMIT_SHA}
+    command: ["/usr/local/bin/backup.sh"]
+    depends_on:
+      - cron
+      - postgres
+    environment:
+      - S3_ENDPOINT=${S3_ENDPOINT}
+      - PGHOST=postgres
+      - PGUSER=${USERNAME}
+      - PGPASSWORD=${PASSWORD}
+      - S3_BUCKET=${S3_BUCKET}
+      - S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
+      - S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}
+      - S3_FOLDER=postgres-daily
+    networks:
+      - postgres-net
+    deploy:
+      mode: replicated
+      replicas: 0
+      labels:
+        - "swarm.cronjob.enable=true"
+        - "swarm.cronjob.schedule=40 3 * * *"
+        - "swarm.cronjob.skip-running=true"
+      restart_policy:
+        condition: none
+
+  postgres-backup-weekly:
+    image: ghcr.io/${OWNER_NAME}/postgres-backup:${GIT_COMMIT_SHA}
+    command: ["/usr/local/bin/backup.sh"]
+    depends_on:
+      - cron
+      - postgres
+    environment:
+      - S3_ENDPOINT=${S3_ENDPOINT}
+      - PGHOST=postgres
+      - PGUSER=${USERNAME}
+      - PGPASSWORD=${PASSWORD}
+      - S3_BUCKET=${S3_BUCKET}
+      - S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
+      - S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}
+      - S3_FOLDER=postgres-weekly
+    networks:
+      - postgres-net
+    deploy:
+      mode: replicated
+      replicas: 0
+      labels:
+        - "swarm.cronjob.enable=true"
+        - "swarm.cronjob.schedule=30 3 * * 2"
+        - "swarm.cronjob.skip-running=true"
+      restart_policy:
+        condition: none
+
   caddy-backup-daily:
     image: ghcr.io/${OWNER_NAME}/caddy-backup:${GIT_COMMIT_SHA}
     command: ["/usr/local/bin/backup.sh"]
@@ -278,8 +387,15 @@ networks:
     attachable: true
     driver_opts:
       encrypted: "true"
+  postgres-net:
+    driver: overlay
+    attachable: true
+    driver_opts:
+      encrypted: "true"
 
 volumes:
   mongodb-rs-1-data:
+  postgres-data:
+  pgadmin-data:
   grafana-data:
   caddy-data:

--- a/local_deploy.js
+++ b/local_deploy.js
@@ -60,6 +60,7 @@ const main = async () => {
         USERNAME: username,
         PASSWORD: password,
         MONGO_RS_KEYFILE_CONTENT: keyContent,
+        EMAIL: 'root@local.dev',
     };
 
     console.log("\nDeploying stack...");
@@ -75,6 +76,7 @@ const main = async () => {
         if (code === 0) {
             console.log("\nDeployment successful!");
             console.log(`Mongo Viewer available at: http://<docker vm ip>:5000`);
+            console.log(`pgAdmin available at: http://<docker vm ip>:5050`);
         } else {
             console.error(`\nDeployment failed with code ${code}`);
             process.exit(code);

--- a/postgres-backup/Dockerfile
+++ b/postgres-backup/Dockerfile
@@ -1,0 +1,9 @@
+FROM postgres:17
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3-pip ca-certificates \
+    && pip3 install --no-cache-dir --break-system-packages awscli \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY backup.sh /usr/local/bin/backup.sh
+RUN chmod +x /usr/local/bin/backup.sh

--- a/postgres-backup/backup.sh
+++ b/postgres-backup/backup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Required environment variables:
+: "${PGHOST:?need to set PGHOST}"
+: "${PGUSER:?need to set PGUSER}"
+: "${PGPASSWORD:?need to set PGPASSWORD}"
+: "${S3_BUCKET:?need to set S3_BUCKET}"
+: "${S3_ACCESS_KEY_ID:?need to set S3_ACCESS_KEY_ID}"
+: "${S3_SECRET_ACCESS_KEY:?need to set S3_SECRET_ACCESS_KEY}"
+: "${S3_FOLDER:?need to set S3_FOLDER}"
+: "${S3_ENDPOINT:?need to set S3_ENDPOINT}"
+
+TS="$(date +'%Y-%m-%d_%H-%M')"
+ARCHIVE="/tmp/pgdump-${TS}.sql.gz"
+
+echo "[+] Dumping PostgreSQL → ${ARCHIVE}"
+pg_dumpall -h "${PGHOST}" -U "${PGUSER}" | gzip > "${ARCHIVE}"
+
+UPLOAD_PATH="s3://${S3_BUCKET}/${S3_FOLDER}/pgdump-${TS}.sql.gz"
+echo "[+] Uploading to S3: ${UPLOAD_PATH}"
+
+export AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$S3_SECRET_ACCESS_KEY"
+
+aws --endpoint-url="$S3_ENDPOINT" s3 cp "$ARCHIVE" "$UPLOAD_PATH"
+
+echo "[+] Done."


### PR DESCRIPTION
## Summary
This PR adds PostgreSQL database support to the infrastructure stack with automated hourly, daily, and weekly backup capabilities to S3-compatible storage.

## Key Changes

- **PostgreSQL Service**: Added PostgreSQL 17 database service with persistent volume storage and network isolation
- **pgAdmin4 Integration**: Added pgAdmin4 web UI for database management, exposed via Caddy reverse proxy at `pgadmin.nu31.space`
- **Automated Backups**: Implemented three scheduled backup services:
  - Hourly backups (runs at :10 of every hour)
  - Daily backups (runs at 3:40 AM daily)
  - Weekly backups (runs at 3:30 AM every Tuesday)
- **Backup Infrastructure**: Created custom Docker image with PostgreSQL and AWS CLI tools for S3 uploads
- **Network Configuration**: Added dedicated `postgres-net` overlay network for database services with encryption enabled
- **Local Development**: Added PostgreSQL and pgAdmin4 services to local development stack with exposed ports (5432 and 5050)
- **CI/CD Updates**: Extended GitHub Actions workflow to build postgres-backup image and pass EMAIL variable to deployment

## Implementation Details

- Backup script uses `pg_dumpall` for complete database dumps, compressed with gzip
- Backups are organized in S3 by frequency (postgres-hourly, postgres-daily, postgres-weekly folders)
- Backup services use Docker Swarm cronjob labels for scheduling
- All services configured with environment variables for credentials and S3 endpoint
- pgAdmin4 configured in server mode for multi-user access
- Local development uses hardcoded email (root@local.dev) while production uses environment variable

https://claude.ai/code/session_01VMduu6tUNow3KCBN6zbSwy