### PR TITLE
Add PostgreSQL service with automated backups

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -45,6 +45,9 @@ jobs:
           - name: telegraf
             context: ./telegraf
             image: telegraf
+          - name: postgres-backup
+            context: ./postgres-backup
+            image: postgres-backup
     
     runs-on: ubuntu-latest
     permissions:

--- a/caddy/CaddyFile
+++ b/caddy/CaddyFile
@@ -33,3 +33,7 @@ compass.nu31.space {
         reverse_proxy * infra_mongo-rs-viewer:8080
 }
 
+pgweb.nu31.space {
+        reverse_proxy * infra_postgres-viewer:8081
+}
+

--- a/docker-stack.local.yml
+++ b/docker-stack.local.yml
@@ -54,8 +54,40 @@ services:
       restart_policy:
         condition: on-failure
 
+  postgres-1:
+    image: postgres:17.4
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=${USERNAME}
+      - POSTGRES_PASSWORD=${PASSWORD}
+    volumes:
+      - postgres-1-data:/var/lib/postgresql/data
+    networks:
+      - postgres-net
+    deploy:
+      restart_policy:
+        condition: on-failure
+
+  postgres-viewer:
+    image: sosedoff/pgweb:0.16.2
+    ports:
+      - "5001:8081"
+    environment:
+      - PGWEB_DATABASE_URL=postgres://${USERNAME}:${PASSWORD}@postgres-1:5432/?sslmode=disable
+    networks:
+      - postgres-net
+    deploy:
+      restart_policy:
+        condition: on-failure
+
 networks:
   mongo-rs-net:
+    driver: overlay
+    attachable: true
+    driver_opts:
+      encrypted: "true"
+  postgres-net:
     driver: overlay
     attachable: true
     driver_opts:
@@ -63,3 +95,4 @@ networks:
 
 volumes:
   mongodb-rs-1-data:
+  postgres-1-data:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -149,6 +149,114 @@ services:
       restart_policy:
         condition: none
 
+  postgres-1:
+    image: postgres:17.4
+    environment:
+      - POSTGRES_USER=${USERNAME}
+      - POSTGRES_PASSWORD=${PASSWORD}
+    volumes:
+      - postgres-1-data:/var/lib/postgresql/data
+    networks:
+      - postgres-net
+    deploy:
+      restart_policy:
+        condition: on-failure
+
+  postgres-viewer:
+    image: sosedoff/pgweb:0.16.2
+    environment:
+      - PGWEB_DATABASE_URL=postgres://${USERNAME}:${PASSWORD}@postgres-1:5432/?sslmode=disable
+    networks:
+      - postgres-net
+      - reverse-proxy
+    deploy:
+      restart_policy:
+        condition: on-failure
+
+  postgres-backup-hourly:
+    image: ghcr.io/${OWNER_NAME}/postgres-backup:${GIT_COMMIT_SHA}
+    command: ["/usr/local/bin/backup.sh"]
+    depends_on:
+      - cron
+      - postgres-1
+    environment:
+      - S3_ENDPOINT=${S3_ENDPOINT}
+      - PGHOST=postgres-1
+      - PGPORT=5432
+      - PGUSER=${USERNAME}
+      - PGPASSWORD=${PASSWORD}
+      - S3_BUCKET=${S3_BUCKET}
+      - S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
+      - S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}
+      - S3_FOLDER=postgres-hourly
+    networks:
+      - postgres-net
+    deploy:
+      mode: replicated
+      replicas: 0
+      labels:
+        - "swarm.cronjob.enable=true"
+        - "swarm.cronjob.schedule=10 * * * *"
+        - "swarm.cronjob.skip-running=true"
+      restart_policy:
+        condition: none
+
+  postgres-backup-daily:
+    image: ghcr.io/${OWNER_NAME}/postgres-backup:${GIT_COMMIT_SHA}
+    command: ["/usr/local/bin/backup.sh"]
+    depends_on:
+      - cron
+      - postgres-1
+    environment:
+      - S3_ENDPOINT=${S3_ENDPOINT}
+      - PGHOST=postgres-1
+      - PGPORT=5432
+      - PGUSER=${USERNAME}
+      - PGPASSWORD=${PASSWORD}
+      - S3_BUCKET=${S3_BUCKET}
+      - S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
+      - S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}
+      - S3_FOLDER=postgres-daily
+    networks:
+      - postgres-net
+    deploy:
+      mode: replicated
+      replicas: 0
+      labels:
+        - "swarm.cronjob.enable=true"
+        - "swarm.cronjob.schedule=40 3 * * *"
+        - "swarm.cronjob.skip-running=true"
+      restart_policy:
+        condition: none
+
+  postgres-backup-weekly:
+    image: ghcr.io/${OWNER_NAME}/postgres-backup:${GIT_COMMIT_SHA}
+    command: ["/usr/local/bin/backup.sh"]
+    depends_on:
+      - cron
+      - postgres-1
+    environment:
+      - S3_ENDPOINT=${S3_ENDPOINT}
+      - PGHOST=postgres-1
+      - PGPORT=5432
+      - PGUSER=${USERNAME}
+      - PGPASSWORD=${PASSWORD}
+      - S3_BUCKET=${S3_BUCKET}
+      - S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
+      - S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}
+      - S3_FOLDER=postgres-weekly
+    networks:
+      - postgres-net
+    deploy:
+      mode: replicated
+      replicas: 0
+      labels:
+        - "swarm.cronjob.enable=true"
+        - "swarm.cronjob.schedule=30 3 * * 2"
+        - "swarm.cronjob.skip-running=true"
+      restart_policy:
+        condition: none
+
   caddy-backup-daily:
     image: ghcr.io/${OWNER_NAME}/caddy-backup:${GIT_COMMIT_SHA}
     command: ["/usr/local/bin/backup.sh"]
@@ -278,8 +386,14 @@ networks:
     attachable: true
     driver_opts:
       encrypted: "true"
+  postgres-net:
+    driver: overlay
+    attachable: true
+    driver_opts:
+      encrypted: "true"
 
 volumes:
   mongodb-rs-1-data:
+  postgres-1-data:
   grafana-data:
   caddy-data:

--- a/local_deploy.js
+++ b/local_deploy.js
@@ -75,6 +75,8 @@ const main = async () => {
         if (code === 0) {
             console.log("\nDeployment successful!");
             console.log(`Mongo Viewer available at: http://<docker vm ip>:5000`);
+            console.log(`Postgres available at: localhost:5432`);
+            console.log(`Postgres Viewer available at: http://<docker vm ip>:5001`);
         } else {
             console.error(`\nDeployment failed with code ${code}`);
             process.exit(code);

--- a/postgres-backup/Dockerfile
+++ b/postgres-backup/Dockerfile
@@ -1,0 +1,9 @@
+FROM postgres:17.4
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3-pip ca-certificates \
+    && pip3 install --no-cache-dir --break-system-packages awscli \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY backup.sh /usr/local/bin/backup.sh
+RUN chmod +x /usr/local/bin/backup.sh

--- a/postgres-backup/backup.sh
+++ b/postgres-backup/backup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Required environment variables:
+: "${PGHOST:?need to set PGHOST}"
+: "${PGPORT:?need to set PGPORT}"
+: "${PGUSER:?need to set PGUSER}"
+: "${PGPASSWORD:?need to set PGPASSWORD}"
+: "${S3_BUCKET:?need to set S3_BUCKET}"
+: "${S3_ACCESS_KEY_ID:?need to set S3_ACCESS_KEY_ID}"
+: "${S3_SECRET_ACCESS_KEY:?need to set S3_SECRET_ACCESS_KEY}"
+: "${S3_FOLDER:?need to set S3_FOLDER}"
+: "${S3_ENDPOINT:?need to set S3_ENDPOINT}"
+
+TS="$(date +'%Y-%m-%d_%H-%M')"
+ARCHIVE="/tmp/pgdump-${TS}.sql.gz"
+
+echo "[+] Dumping PostgreSQL → ${ARCHIVE}"
+pg_dumpall | gzip > "${ARCHIVE}"
+
+UPLOAD_PATH="s3://${S3_BUCKET}/${S3_FOLDER}/pgdump-${TS}.sql.gz"
+echo "[+] Uploading to S3: ${UPLOAD_PATH}"
+
+export AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$S3_SECRET_ACCESS_KEY"
+
+aws --endpoint-url="$S3_ENDPOINT" s3 cp "$ARCHIVE" "$UPLOAD_PATH"
+
+echo "[+] Done."


### PR DESCRIPTION
## Summary
This PR adds a complete PostgreSQL infrastructure to the Docker stack, including the database service, a web viewer, and automated backup jobs at multiple intervals with S3 storage.

## Key Changes
- **PostgreSQL Service**: Added `postgres-1` service running PostgreSQL 17.4 with persistent volume storage
- **Database Viewer**: Integrated pgweb (sosedoff/pgweb) for web-based database management accessible via `pgweb.nu31.space`
- **Automated Backups**: Implemented three scheduled backup jobs:
  - Hourly backups (runs at :10 of every hour)
  - Daily backups (runs at 3:40 AM daily)
  - Weekly backups (runs at 3:30 AM every Tuesday)
- **Backup Infrastructure**: Created custom Docker image with PostgreSQL and AWS CLI for S3 uploads
- **Network Configuration**: Added dedicated `postgres-net` overlay network for PostgreSQL services
- **Local Development**: Added port mappings for local development (5432 for PostgreSQL, 5001 for pgweb viewer)
- **Documentation**: Updated deployment scripts to display PostgreSQL access information

## Implementation Details
- Backup jobs use the swarm cronjob scheduler with `skip-running=true` to prevent concurrent executions
- All backups are compressed (gzip) and uploaded to S3 with folder separation by frequency
- PostgreSQL credentials are managed via environment variables (USERNAME/PASSWORD)
- The backup script includes comprehensive error handling with required environment variable validation
- Caddy reverse proxy configured to expose pgweb at `pgweb.nu31.space`
- GitHub Actions workflow updated to build the postgres-backup image

https://claude.ai/code/session_019R5b86YMMoF6rVS1NhvLGY