### PR TITLE
Add PostgreSQL database with backup and viewer services

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -45,6 +45,9 @@ jobs:
           - name: telegraf
             context: ./telegraf
             image: telegraf
+          - name: postgres-backup
+            context: ./postgres-backup
+            image: postgres-backup
     
     runs-on: ubuntu-latest
     permissions:

--- a/caddy/CaddyFile
+++ b/caddy/CaddyFile
@@ -26,7 +26,7 @@ grafana.nu31.space {
 }
 
 prismo.nu31.space {
-        reverse_proxy * prismo-web-flasher_app:80
+        reverse_proxy * prismo-web-flasher_app:3000
 }
 
 compass.nu31.space {

--- a/caddy/CaddyFile
+++ b/caddy/CaddyFile
@@ -33,3 +33,7 @@ compass.nu31.space {
         reverse_proxy * infra_mongo-rs-viewer:8080
 }
 
+pgweb.nu31.space {
+        reverse_proxy * infra_postgres-viewer:8081
+}
+

--- a/docker-stack.local.yml
+++ b/docker-stack.local.yml
@@ -65,6 +65,12 @@ services:
       - postgres-1-data:/var/lib/postgresql/data
     networks:
       - postgres-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${USERNAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     deploy:
       restart_policy:
         condition: on-failure
@@ -80,6 +86,7 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
+        delay: 5s
 
 networks:
   mongo-rs-net:

--- a/docker-stack.local.yml
+++ b/docker-stack.local.yml
@@ -54,8 +54,40 @@ services:
       restart_policy:
         condition: on-failure
 
+  postgres-1:
+    image: postgres:17.4
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=${USERNAME}
+      - POSTGRES_PASSWORD=${PASSWORD}
+    volumes:
+      - postgres-1-data:/var/lib/postgresql/data
+    networks:
+      - postgres-net
+    deploy:
+      restart_policy:
+        condition: on-failure
+
+  postgres-viewer:
+    image: sosedoff/pgweb:0.16.2
+    ports:
+      - "5001:8081"
+    environment:
+      - PGWEB_DATABASE_URL=postgres://${USERNAME}:${PASSWORD}@postgres-1:5432/?sslmode=disable
+    networks:
+      - postgres-net
+    deploy:
+      restart_policy:
+        condition: on-failure
+
 networks:
   mongo-rs-net:
+    driver: overlay
+    attachable: true
+    driver_opts:
+      encrypted: "true"
+  postgres-net:
     driver: overlay
     attachable: true
     driver_opts:
@@ -63,3 +95,4 @@ networks:
 
 volumes:
   mongodb-rs-1-data:
+  postgres-1-data:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -158,6 +158,12 @@ services:
       - postgres-1-data:/var/lib/postgresql/data
     networks:
       - postgres-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${USERNAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     deploy:
       restart_policy:
         condition: on-failure
@@ -172,6 +178,7 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
+        delay: 5s
 
   postgres-backup-hourly:
     image: ghcr.io/${OWNER_NAME}/postgres-backup:${GIT_COMMIT_SHA}

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -149,6 +149,114 @@ services:
       restart_policy:
         condition: none
 
+  postgres-1:
+    image: postgres:17.4
+    environment:
+      - POSTGRES_USER=${USERNAME}
+      - POSTGRES_PASSWORD=${PASSWORD}
+    volumes:
+      - postgres-1-data:/var/lib/postgresql/data
+    networks:
+      - postgres-net
+    deploy:
+      restart_policy:
+        condition: on-failure
+
+  postgres-viewer:
+    image: sosedoff/pgweb:0.16.2
+    environment:
+      - PGWEB_DATABASE_URL=postgres://${USERNAME}:${PASSWORD}@postgres-1:5432/?sslmode=disable
+    networks:
+      - postgres-net
+      - reverse-proxy
+    deploy:
+      restart_policy:
+        condition: on-failure
+
+  postgres-backup-hourly:
+    image: ghcr.io/${OWNER_NAME}/postgres-backup:${GIT_COMMIT_SHA}
+    command: ["/usr/local/bin/backup.sh"]
+    depends_on:
+      - cron
+      - postgres-1
+    environment:
+      - S3_ENDPOINT=${S3_ENDPOINT}
+      - PGHOST=postgres-1
+      - PGPORT=5432
+      - PGUSER=${USERNAME}
+      - PGPASSWORD=${PASSWORD}
+      - S3_BUCKET=${S3_BUCKET}
+      - S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
+      - S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}
+      - S3_FOLDER=postgres-hourly
+    networks:
+      - postgres-net
+    deploy:
+      mode: replicated
+      replicas: 0
+      labels:
+        - "swarm.cronjob.enable=true"
+        - "swarm.cronjob.schedule=10 * * * *"
+        - "swarm.cronjob.skip-running=true"
+      restart_policy:
+        condition: none
+
+  postgres-backup-daily:
+    image: ghcr.io/${OWNER_NAME}/postgres-backup:${GIT_COMMIT_SHA}
+    command: ["/usr/local/bin/backup.sh"]
+    depends_on:
+      - cron
+      - postgres-1
+    environment:
+      - S3_ENDPOINT=${S3_ENDPOINT}
+      - PGHOST=postgres-1
+      - PGPORT=5432
+      - PGUSER=${USERNAME}
+      - PGPASSWORD=${PASSWORD}
+      - S3_BUCKET=${S3_BUCKET}
+      - S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
+      - S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}
+      - S3_FOLDER=postgres-daily
+    networks:
+      - postgres-net
+    deploy:
+      mode: replicated
+      replicas: 0
+      labels:
+        - "swarm.cronjob.enable=true"
+        - "swarm.cronjob.schedule=40 3 * * *"
+        - "swarm.cronjob.skip-running=true"
+      restart_policy:
+        condition: none
+
+  postgres-backup-weekly:
+    image: ghcr.io/${OWNER_NAME}/postgres-backup:${GIT_COMMIT_SHA}
+    command: ["/usr/local/bin/backup.sh"]
+    depends_on:
+      - cron
+      - postgres-1
+    environment:
+      - S3_ENDPOINT=${S3_ENDPOINT}
+      - PGHOST=postgres-1
+      - PGPORT=5432
+      - PGUSER=${USERNAME}
+      - PGPASSWORD=${PASSWORD}
+      - S3_BUCKET=${S3_BUCKET}
+      - S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
+      - S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}
+      - S3_FOLDER=postgres-weekly
+    networks:
+      - postgres-net
+    deploy:
+      mode: replicated
+      replicas: 0
+      labels:
+        - "swarm.cronjob.enable=true"
+        - "swarm.cronjob.schedule=30 3 * * 2"
+        - "swarm.cronjob.skip-running=true"
+      restart_policy:
+        condition: none
+
   caddy-backup-daily:
     image: ghcr.io/${OWNER_NAME}/caddy-backup:${GIT_COMMIT_SHA}
     command: ["/usr/local/bin/backup.sh"]
@@ -278,8 +386,14 @@ networks:
     attachable: true
     driver_opts:
       encrypted: "true"
+  postgres-net:
+    driver: overlay
+    attachable: true
+    driver_opts:
+      encrypted: "true"
 
 volumes:
   mongodb-rs-1-data:
+  postgres-1-data:
   grafana-data:
   caddy-data:

--- a/local_deploy.js
+++ b/local_deploy.js
@@ -75,6 +75,8 @@ const main = async () => {
         if (code === 0) {
             console.log("\nDeployment successful!");
             console.log(`Mongo Viewer available at: http://<docker vm ip>:5000`);
+            console.log(`Postgres available at: localhost:5432`);
+            console.log(`Postgres Viewer available at: http://<docker vm ip>:5001`);
         } else {
             console.error(`\nDeployment failed with code ${code}`);
             process.exit(code);

--- a/postgres-backup/Dockerfile
+++ b/postgres-backup/Dockerfile
@@ -1,0 +1,9 @@
+FROM postgres:17.4
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3-pip ca-certificates \
+    && pip3 install --no-cache-dir --break-system-packages awscli \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY backup.sh /usr/local/bin/backup.sh
+RUN chmod +x /usr/local/bin/backup.sh

--- a/postgres-backup/backup.sh
+++ b/postgres-backup/backup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Required environment variables:
+: "${PGHOST:?need to set PGHOST}"
+: "${PGPORT:?need to set PGPORT}"
+: "${PGUSER:?need to set PGUSER}"
+: "${PGPASSWORD:?need to set PGPASSWORD}"
+: "${S3_BUCKET:?need to set S3_BUCKET}"
+: "${S3_ACCESS_KEY_ID:?need to set S3_ACCESS_KEY_ID}"
+: "${S3_SECRET_ACCESS_KEY:?need to set S3_SECRET_ACCESS_KEY}"
+: "${S3_FOLDER:?need to set S3_FOLDER}"
+: "${S3_ENDPOINT:?need to set S3_ENDPOINT}"
+
+TS="$(date +'%Y-%m-%d_%H-%M')"
+ARCHIVE="/tmp/pgdump-${TS}.sql.gz"
+
+echo "[+] Dumping PostgreSQL → ${ARCHIVE}"
+pg_dumpall | gzip > "${ARCHIVE}"
+
+UPLOAD_PATH="s3://${S3_BUCKET}/${S3_FOLDER}/pgdump-${TS}.sql.gz"
+echo "[+] Uploading to S3: ${UPLOAD_PATH}"
+
+export AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$S3_SECRET_ACCESS_KEY"
+
+aws --endpoint-url="$S3_ENDPOINT" s3 cp "$ARCHIVE" "$UPLOAD_PATH"
+
+echo "[+] Done."


### PR DESCRIPTION
## Summary
This PR adds PostgreSQL database support to the infrastructure stack with automated backup capabilities and a web-based database viewer.

## Key Changes

- **PostgreSQL Service**: Added `postgres-1` service running PostgreSQL 17.4 with health checks and persistent storage
- **Database Viewer**: Integrated pgweb (`postgres-viewer`) for web-based PostgreSQL administration accessible at `pgweb.nu31.space`
- **Automated Backups**: Implemented three scheduled backup jobs:
  - Hourly backups (runs at 10 minutes past each hour)
  - Daily backups (runs at 3:40 AM)
  - Weekly backups (runs at 3:30 AM on Tuesdays)
- **Backup Infrastructure**: Created custom Docker image (`postgres-backup`) that dumps PostgreSQL databases and uploads them to S3-compatible storage
- **Network Configuration**: Added dedicated `postgres-net` overlay network for PostgreSQL services with encryption enabled
- **Local Development**: Updated local compose file with exposed ports (5432 for PostgreSQL, 5001 for pgweb)
- **Caddy Configuration**: Added reverse proxy route for pgweb and fixed prismo service port mapping (80 → 3000)
- **CI/CD**: Added postgres-backup image build to GitHub Actions deployment workflow
- **Documentation**: Updated local deployment script to display PostgreSQL connection information

## Implementation Details

- PostgreSQL backups are compressed with gzip and stored with timestamps in S3
- Backup jobs use swarm cronjob labels for scheduling and skip running if already in progress
- All PostgreSQL services use environment variables for credentials and S3 configuration
- Health checks ensure PostgreSQL is ready before dependent services start
- Backup containers have replicas set to 0 and are triggered by the cron scheduler

https://claude.ai/code/session_01Dvz89EwtHywzyrMAeBEYnp